### PR TITLE
feat: add payment model

### DIFF
--- a/src/models/PaymentModel.js
+++ b/src/models/PaymentModel.js
@@ -1,0 +1,18 @@
+import mongoose from 'mongoose';
+
+const paymentSchema = new mongoose.Schema({
+    subscriptionId: { type: mongoose.Schema.Types.ObjectId, ref: 'Subscription', required: true },
+    orderId: { type: mongoose.Schema.Types.ObjectId, ref: 'Order', default: null },
+
+    amount: { type: Number, required: true },
+    status: { type: String, enum: ['pending', 'completed', 'failed'], default: 'pending', required: true },
+    gateway: { type: String, enum: ['multisafepay', 'paypal', 'redsys'], required: true },
+    transactionId: { type: String, default: null },
+    paymentDate: { type: Date, default: null }
+}, {
+    timestamps: true
+});
+
+const PaymentModel = mongoose.model('Payment', paymentSchema);
+
+export default PaymentModel;


### PR DESCRIPTION
Se ha creado el modelo de Payment.

subscriptionId -> obligatorio (todo pago proviene de una suscripción)
orderId -> opcional/null inicialmente porque solo se completa cuando se crea la orden tras un pago correcto.

gateway -> la pasarela de pago que fue utilizada: multisafepay, paypal, redsys... etc
transactionId -> ID devuelto por la pasarela, que a principio es null hasta ser procesado
paymentDate -> fecha del pago que así como arriba, es null hasta completarse...